### PR TITLE
update list of programs to nauty 2.8.8

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,9 +25,9 @@ autoreconf -vfi
 ./configure --disable-popcnt --disable-clz --enable-generic --enable-tls
 make
 
-programs="addedgeg amtog biplabg catg complg converseg copyg cubhamg deledgeg delptg directg dreadnaut dretodot dretog \
-  genbg genbgL geng genquarticg genrang genspecialg gentourng gentreeg hamheuristic labelg linegraphg listg multig newedgeg \
-  planarg ranlabg showg subdivideg twohamg vcolg watercluster2 NRswitchg"
+programs="addedgeg amtog biplabg catg complg converseg copyg countneg cubhamg deledgeg delptg directg dreadnaut dretodot dretog \
+  genbg genbgL geng genktreeg genquarticg genrang genspecialg gentourng gentreeg hamheuristic labelg linegraphg listg multig newedgeg \
+  planarg ranlabg ransubg showg subdivideg twohamg vcolg watercluster2 NRswitchg"
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
     check_output=`make checks`

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,9 +25,12 @@ autoreconf -vfi
 ./configure --disable-popcnt --disable-clz --enable-generic --enable-tls
 make
 
-programs="addedgeg amtog biplabg catg complg converseg copyg countneg cubhamg deledgeg delptg directg dreadnaut dretodot dretog \
-  genbg genbgL geng genktreeg genquarticg genrang genspecialg gentourng gentreeg hamheuristic labelg linegraphg listg multig newedgeg \
-  planarg ranlabg ransubg showg subdivideg twohamg vcolg watercluster2 NRswitchg"
+programs="addedgeg addptg amtog ancestorg assembleg biplabg catg complg converseg copyg \
+  countg countneg cubhamg deledgeg delptg dimacs2g directg dreadnaut dretodot \
+  dretog edgetransg genbg genbgL geng gengL genposetg genquarticg genrang \
+  genspecialg gentourng gentreeg genktreeg hamheuristic labelg linegraphg listg \
+  multig nbrhoodg newedgeg pickg planarg productg ranlabg ransubg shortg showg \
+  subdivideg twohamg underlyingg vcolg watercluster2 NRswitchg"
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
     check_output=`make checks`

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-Add-missing-header-for-isatty-on-Windows.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This PR updates the list of programs of nauty to the list of version 2.8.8. For instance, genktreeg has been introduced in version 2.8.8 and we want to use it in https://github.com/sagemath/sage/pull/36924